### PR TITLE
Dynamic Uno - Bump Omnibus version

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -21,5 +21,5 @@ RUN /platform/install-ruby.sh && rm -rf "/usr/local/src/ruby-${RUBY_VERSION}"
 
 RUN gem install bundler --no-ri --no-rdoc
 
-ENV OMNIBUS_VERSION 5.4.0
+ENV OMNIBUS_VERSION 5.5.0
 RUN gem install omnibus --version "$OMNIBUS_VERSION" --no-ri --no-rdoc

--- a/centos-6/config.mk
+++ b/centos-6/config.mk
@@ -1,3 +1,3 @@
 export BASE_IMAGE = centos:6
 export PLATFORM = el
-export GIT_FROM_RPMFORGE_PKG = http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm
+export GIT_FROM_RPMFORGE_PKG = http://repository.it4i.cz/mirrors/repoforge/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm

--- a/platform/el/install-deps.sh
+++ b/platform/el/install-deps.sh
@@ -2,6 +2,7 @@
 set -o errexit
 set -o nounset
 
+yum update yum
 yum install -y epel-release
 yum install -y wget sudo which fakeroot
 yum groupinstall -y "Development tools"


### PR DESCRIPTION
We're upgrading the Omnibus version in
https://github.com/aptible/omnibus-aptible-toolbelt/pull/17, so we might
as well update the version in the builder as well to make sure we don't
have to install too many gems when building.