### PR TITLE
Update CentOS CA certificates

### DIFF
--- a/platform/el/install-deps.sh
+++ b/platform/el/install-deps.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o nounset
 
-yum update -y yum
+yum update -y yum ca-certificates
 yum install -y epel-release
 yum install -y wget sudo which fakeroot
 yum groupinstall -y "Development tools"


### PR DESCRIPTION
This will fix the CentOS build for https://github.com/aptible/omnibus-aptible-toolbelt/pull/72